### PR TITLE
Fix misspelt "avilable" to "available"

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
                 </div>
                 <div class="options">
                     <p id="offline-status">Offline Status: CHECKING</p>
-                    <p>Offline Cores will be avilable soon.</p>
+                    <p>Offline Cores will be available soon.</p>
                     <p class="hide">Remove All Saved Versions: <button id="remove-version" onclick="removeallsaved()">Remove All</button></p>
                     <div id="installbox"><p id="installboxtext">Install PWA:</p> <button id="install">Install</button></div>
                     </div>


### PR DESCRIPTION
The settings popup menu has had this tiny spelling error for a little bit so i might as well fix it while im here.